### PR TITLE
Shrink game window in editor previews

### DIFF
--- a/src/project.godot
+++ b/src/project.godot
@@ -24,6 +24,8 @@ Transition="*res://autoloads/transition/transition.tscn"
 window/size/viewport_width=1920
 window/size/viewport_height=1080
 window/stretch/mode="canvas_items"
+window/size/window_width_override.editor=1152
+window/size/window_height_override.editor=648
 
 [dotnet]
 


### PR DESCRIPTION
The window's legitimately as big as my monitor right now and it sucks. Please, I beg.